### PR TITLE
feat(v2-batch-submissions): swallow `BlockAlreadyInDbError` during batch submissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "eos_on_int"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "chain_ids",
  "common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,7 +2386,7 @@ dependencies = [
 
 [[package]]
 name = "int_on_eos"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "chain_ids",
  "common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,7 +539,7 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "btc_on_int"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bitcoin 0.29.0",
  "bitcoin 0.29.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "int_on_algo"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "algorand",
  "chain_ids",

--- a/v2_bridges/btc_on_int/Cargo.toml
+++ b/v2_bridges/btc_on_int/Cargo.toml
@@ -2,7 +2,7 @@
 license = "MIT"
 publish = false
 edition = "2021"
-version = "1.1.0"
+version = "1.2.0"
 name = "btc_on_int"
 readme = "README.md"
 rust-version = "1.56"

--- a/v2_bridges/btc_on_int/src/int/submit_int_block.rs
+++ b/v2_bridges/btc_on_int/src/int/submit_int_block.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use common::{core_type::CoreType, traits::DatabaseInterface, types::Result};
+use common::{core_type::CoreType, traits::DatabaseInterface, types::Result, AppError};
 use common_eth::{
     check_for_parent_of_eth_block_in_state,
     maybe_add_eth_block_and_receipts_to_db_and_return_state,
@@ -75,10 +75,24 @@ pub fn submit_int_blocks_to_core<D: DatabaseInterface>(db: &D, blocks: &str) -> 
         .and_then(|_| db.start_transaction())
         .and_then(|_| EthSubmissionMaterialJsons::from_str(blocks))
         .and_then(|jsons| {
-            jsons
-                .iter()
-                .map(|block| submit_int_block(db, block))
-                .collect::<Result<Vec<_>>>()
+            let mut outputs = vec![];
+
+            for json in jsons.iter() {
+                match submit_int_block(db, json) {
+                    Ok(o) => {
+                        outputs.push(o);
+                        continue;
+                    },
+                    Err(AppError::BlockAlreadyInDbError(e)) => {
+                        warn!("block already in db error: {e}");
+                        info!("moving on to next block in batch!");
+                        continue;
+                    },
+                    Err(e) => return Err(e),
+                }
+            }
+
+            Ok(outputs)
         })
         .map(IntOutputs::new)
         .and_then(|outputs| {
@@ -250,5 +264,99 @@ mod tests {
 
         // NOTE: Check the tx is decodable...
         assert!(convert_hex_tx_to_btc_transaction(tx_info.btc_signed_tx).is_ok());
+    }
+
+    #[test]
+    fn should_batch_submit_int_blocks_successfully_even_if_one_already_in_db() {
+        // Init the BTC side...
+        let btc_pk = "93GJ65qHNjGFHzQVTzEEAdBS7vMxe3XASfWE8RUASSfd3EtfmzP";
+        let db = get_test_database();
+        let btc_db_utils = BtcDbUtils::new(&db);
+        let btc_state = BtcState::init(&db);
+        let btc_fee = 15;
+        let btc_difficulty = 1;
+        let btc_network = "Testnet";
+        let btc_canon_to_tip_length = 2;
+        let btc_block_0 = get_sample_btc_submission_material_json_str_n(0);
+        init_btc_core(
+            btc_state,
+            &btc_block_0,
+            btc_fee,
+            btc_difficulty,
+            btc_network,
+            btc_canon_to_tip_length,
+        )
+        .unwrap();
+
+        // NOTE: Overwrite the BTC private key fields since they're randomly generated upon init.
+        let btc_pk = BtcPrivateKey::from_wif(btc_pk).unwrap();
+        let address = btc_pk.to_p2pkh_btc_address();
+        btc_db_utils.put_btc_private_key_in_db(&btc_pk).unwrap();
+        btc_db_utils.put_btc_address_in_db(&address).unwrap();
+        btc_db_utils
+            .put_btc_pub_key_slice_in_db(&btc_pk.to_public_key_slice())
+            .unwrap();
+
+        // Init the ETH side...
+        let eth_block_0 = get_sample_int_submission_material_json_str_n(0);
+        let eth_state = EthState::init(&db);
+        let eth_chain_id = 3;
+        let eth_gas_price = 20_000_000_000;
+        let eth_canon_to_tip_length = 2;
+        let ptoken_address_hex = "0x0f513aA8d67820787A8FDf285Bfcf967bF8E4B8b";
+        let ptoken_address = convert_hex_to_eth_address(ptoken_address_hex).unwrap();
+        let router_address_hex = "0x88d19e08cd43bba5761c10c588b2a3d85c75041f";
+        let router_address = convert_hex_to_eth_address(router_address_hex).unwrap();
+        init_int_core(
+            eth_state,
+            &eth_block_0,
+            eth_chain_id,
+            eth_gas_price,
+            eth_canon_to_tip_length,
+            &ptoken_address,
+            &router_address,
+        )
+        .unwrap();
+
+        // NOTE: Overwrite the ETH private key fields since they're randomly generated upon init.
+        let eth_db_utils = EthDbUtils::new(&db);
+        let eth_pk_bytes = hex::decode("262e2a3a7fa5ae40ea04584f20b51fc3918b42e7dd89926b9f4e2196c8a032ba").unwrap();
+        let eth_pk = EthPrivateKey::from_slice(&eth_pk_bytes).unwrap();
+        eth_db_utils.put_eth_private_key_in_db(&eth_pk).unwrap();
+        eth_db_utils
+            .put_public_eth_address_in_db(&eth_pk.to_public_key().to_address())
+            .unwrap();
+
+        // NOTE First we submit enough BTC blocks to have a UTXO to spend...
+        let btc_block_1 = get_sample_btc_submission_material_json_str_n(1);
+        submit_btc_block_to_core(&db, &btc_block_1).unwrap();
+        let btc_block_2 = get_sample_btc_submission_material_json_str_n(2);
+        submit_btc_block_to_core(&db, &btc_block_2).unwrap();
+        let btc_block_3 = get_sample_btc_submission_material_json_str_n(3);
+        submit_btc_block_to_core(&db, &btc_block_3).unwrap();
+        let utxo_nonce = get_utxo_nonce_from_db(&db).unwrap();
+        assert_eq!(utxo_nonce, 1);
+
+        // NOTE: Submit first block, this one has a peg in in it.
+        let int_block_1 = get_sample_int_submission_material_json_str_n(1);
+
+        let submission_string = int_block_1.clone();
+        let block_num = 12000342;
+
+        // NOTE: This totally normal submission should succeed
+        submit_int_block_to_core(&db, &submission_string).unwrap();
+
+        // NOTE: However it will fail a second time due to the block already being in the db...
+        match submit_int_block_to_core(&db, &submission_string) {
+            Ok(_) => panic!("should not have succeeded!"),
+            Err(AppError::BlockAlreadyInDbError(e)) => assert_eq!(e.block_num, block_num),
+            Err(e) => panic!("wrong error received: {e}"),
+        };
+
+        // NOTE: However if the same block forms part of a _batch_ of blocks, the
+        // `BlockAlreadyInDbError` should be swallowed, and thus no errors.
+        let batch = format!("[{submission_string},{submission_string},{submission_string}]");
+        let result = submit_int_blocks_to_core(&db, &batch);
+        assert!(result.is_ok());
     }
 }

--- a/v2_bridges/eos_on_int/Cargo.toml
+++ b/v2_bridges/eos_on_int/Cargo.toml
@@ -2,7 +2,7 @@
 license = "MIT"
 publish = false
 edition = "2021"
-version = "2.0.0"
+version = "2.1.0"
 name = "eos_on_int"
 readme = "README.md"
 rust-version = "1.56"

--- a/v2_bridges/int_on_algo/Cargo.toml
+++ b/v2_bridges/int_on_algo/Cargo.toml
@@ -2,7 +2,7 @@
 license = "MIT"
 publish = false
 edition = "2021"
-version = "1.2.1"
+version = "1.3.0"
 name = "int_on_algo"
 readme = "README.md"
 rust-version = "1.56"

--- a/v2_bridges/int_on_eos/Cargo.toml
+++ b/v2_bridges/int_on_eos/Cargo.toml
@@ -2,7 +2,7 @@
 license = "MIT"
 publish = false
 edition = "2021"
-version = "2.0.0"
+version = "2.1.0"
 name = "int_on_eos"
 readme = "README.md"
 rust-version = "1.56"

--- a/v2_bridges/int_on_eos/src/int/submit_int_block.rs
+++ b/v2_bridges/int_on_eos/src/int/submit_int_block.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use common::{core_type::CoreType, traits::DatabaseInterface, types::Result};
+use common::{core_type::CoreType, traits::DatabaseInterface, types::Result, AppError};
 use common_eth::{
     check_for_parent_of_eth_block_in_state,
     maybe_add_eth_block_and_receipts_to_db_and_return_state,
@@ -80,10 +80,24 @@ pub fn submit_int_blocks_to_core<D: DatabaseInterface>(db: &D, blocks: &str) -> 
         .and_then(|_| db.start_transaction())
         .and_then(|_| EthSubmissionMaterialJsons::from_str(blocks))
         .and_then(|jsons| {
-            jsons
-                .iter()
-                .map(|block| submit_int_block(db, block))
-                .collect::<Result<Vec<_>>>()
+            let mut outputs = vec![];
+
+            for json in jsons.iter() {
+                match submit_int_block(db, json) {
+                    Ok(o) => {
+                        outputs.push(o);
+                        continue;
+                    },
+                    Err(AppError::BlockAlreadyInDbError(e)) => {
+                        warn!("block already in db error: {e}");
+                        info!("moving on to next block in batch!");
+                        continue;
+                    },
+                    Err(e) => return Err(e),
+                }
+            }
+
+            Ok(outputs)
         })
         .map(IntOutputs::new)
         .and_then(|outputs| {
@@ -216,5 +230,74 @@ mod tests {
         let result = output.eos_signed_transactions[0].clone();
         let expected_result = expected_output.eos_signed_transactions[0].clone();
         assert_eq!(result, expected_result);
+    }
+
+    #[test]
+    fn should_batch_submit_int_blocks_successfully_even_if_one_already_in_db() {
+        let db = get_test_database();
+        let vault_address = get_sample_vault_address();
+        let router_address = get_sample_router_address();
+
+        // NOTE: Initialize the EOS core...
+        let eos_chain_id = "4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11";
+        let maybe_eos_account_name = None;
+        let maybe_eos_token_symbol = None;
+        let eos_init_block = get_sample_eos_init_block_1();
+        let is_native = false;
+        initialize_eos_core_inner(
+            &db,
+            eos_chain_id,
+            maybe_eos_account_name,
+            maybe_eos_token_symbol,
+            &eos_init_block,
+            is_native,
+        )
+        .unwrap();
+
+        // NOTE: Overwrite the EOS private key since it's generated randomly above...
+        let eos_pk = get_sample_eos_private_key();
+        eos_pk.write_to_db(&db).unwrap();
+        assert_eq!(EosPrivateKey::get_from_db(&db).unwrap(), eos_pk);
+
+        // NOTE: Initialize the INT side of the core...
+        let int_confirmations = 0;
+        let int_gas_price = 20_000_000_000;
+        let contiguous_int_block_json_strs = get_contiguous_int_block_json_strs();
+        let int_init_block = contiguous_int_block_json_strs[0].clone();
+        let is_native = true;
+        initialize_eth_core_with_vault_and_router_contracts_and_return_state(
+            &int_init_block,
+            &EthChainId::Ropsten,
+            int_gas_price,
+            int_confirmations,
+            IntState::init(&db),
+            &vault_address,
+            &router_address,
+            &VaultUsingCores::IntOnEos,
+            is_native,
+        )
+        .unwrap();
+
+        // NOTE: Add the token dictionary to the db...
+        let dictionary = get_sample_dictionary_1();
+        dictionary.save_to_db(&db).unwrap();
+
+        let submission_string = contiguous_int_block_json_strs[1].clone();
+        let block_num = 12236006;
+        // NOTE: This totally normal submission should succeed
+        submit_int_block_to_core(&db, &submission_string).unwrap();
+
+        // NOTE: However it will fail a second time due to the block already being in the db...
+        match submit_int_block_to_core(&db, &submission_string) {
+            Ok(_) => panic!("should not have succeeded!"),
+            Err(AppError::BlockAlreadyInDbError(e)) => assert_eq!(e.block_num, block_num),
+            Err(e) => panic!("wrong error received: {e}"),
+        };
+
+        // NOTE: However if the same block forms part of a _batch_ of blocks, the
+        // `BlockAlreadyInDbError` should be swallowed, and thus no errors.
+        let batch = format!("[{submission_string},{submission_string},{submission_string}]");
+        let result = submit_int_blocks_to_core(&db, &batch);
+        assert!(result.is_ok());
     }
 }


### PR DESCRIPTION
...per title. Since there's no need to exit in such cases when the batch may contain valid submissions there after.