### PR TITLE
Initialize keystore on startup

### DIFF
--- a/v3_bridges/sentinel-strongbox/src/android/state.rs
+++ b/v3_bridges/sentinel-strongbox/src/android/state.rs
@@ -44,6 +44,7 @@ impl<'a> State<'a> {
         let input_string: String = env.get_string(input)?.into();
         let msg = WebSocketMessagesEncodable::try_from(input_string)?;
         let strongbox = Strongbox::new(env, strongbox_java_class);
+        strongbox.initialize_keystore();
         Ok(State {
             env,
             msg,

--- a/v3_bridges/sentinel-strongbox/src/android/strongbox.rs
+++ b/v3_bridges/sentinel-strongbox/src/android/strongbox.rs
@@ -88,7 +88,7 @@ impl<'a> Strongbox<'a> {
         }
     }
 
-    fn initialize_keystore(&self) -> Result<(), SentinelError> {
+    pub fn initialize_keystore(&self) -> Result<(), SentinelError> {
         if matches!(self.check_keystore_is_initialized(), Ok(true)) {
             debug!("keystore already initialized!");
             Ok(())


### PR DESCRIPTION
Fix the following error:
```
WebSocketMessagesEncodable::Error: sentinel error: chain error: failed to get from db: EthPrivateKey
```